### PR TITLE
Fix issue with outdated default agent pool

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,5 +5,9 @@ trigger:
 
 pr: none
 
+pool:
+  vmImage: "ubuntu-latest"
+
 steps:
+  - checkout: none
   - script: "echo New Sandbox definitions available"


### PR DESCRIPTION
Right now the pipeline fails with the warnings/errors:
```
##[warning]An image label with the label Ubuntu16 does not exist.
,##[error]The remote provider was unable to process the request.
```

This seems to be caused by MS removing the image/pool that they use as a default.

At the same time updated the pipeline to not do a checkout of the repo, as that's not needed for the actions performed by the pipeline